### PR TITLE
fix: skip trying to refresh invalid credentials

### DIFF
--- a/libraries/eve-sso/src/error.rs
+++ b/libraries/eve-sso/src/error.rs
@@ -9,7 +9,7 @@ pub(crate) fn create_error(kind: ErrorKind) -> Error {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Error(Box<ErrorKind>);
+pub struct Error(pub Box<ErrorKind>);
 
 impl Error {
     pub fn kind(&self) -> &ErrorKind {

--- a/services/sso/migrations/2_add_invalid_column.down.sql
+++ b/services/sso/migrations/2_add_invalid_column.down.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE `credentials`
+    DROP COLUMN `is_stale`;

--- a/services/sso/migrations/2_add_invalid_column.up.sql
+++ b/services/sso/migrations/2_add_invalid_column.up.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE `credentials`
+    ADD `is_stale` BOOL DEFAULT FALSE;

--- a/services/sso/src/database/mod.rs
+++ b/services/sso/src/database/mod.rs
@@ -71,7 +71,7 @@ impl Database {
     ) -> anyhow::Result<()> {
         sqlx::query(
             r#"
-            UPDATE `credentials` SET access_token=?, refresh_token=?, expires_at=? WHERE character_id=?
+            UPDATE `credentials` SET access_token=?, refresh_token=?, expires_at=?, is_stale=FALSE WHERE character_id=?
             "#,
         )
         .bind(access_token)
@@ -96,5 +96,16 @@ impl Database {
                 .await?;
 
         Ok(credentials)
+    }
+
+    #[tracing::instrument]
+    pub async fn set_is_stale(&self, character_id: u64, is_stale: bool) -> anyhow::Result<()> {
+        sqlx::query("UPDATE `credentials` SET is_stale=? WHERE character_id=?")
+            .bind(is_stale)
+            .bind(character_id)
+            .execute(&self.db_pool)
+            .await?;
+
+        Ok(())
     }
 }

--- a/services/sso/src/database/model.rs
+++ b/services/sso/src/database/model.rs
@@ -8,4 +8,5 @@ pub struct Credentials {
     pub access_token: String,
     pub updated_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    pub is_stale: bool,
 }

--- a/womp-tools/actions/auth/login_eve.ts
+++ b/womp-tools/actions/auth/login_eve.ts
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import queryString from 'query-string';
 
 const ESI_LOGIN_ENDPOINT = "https://login.eveonline.com/v2/oauth/authorize/";
-const ESI_SCOPE = "publicData esi-wallet.read_character_wallet.v1 esi-search.search_structures.v1 esi-universe.read_structures.v1 esi-assets.read_assets.v1 esi-markets.structure_markets.v1 esi-corporations.read_structures.v1 esi-industry.read_character_jobs.v1 esi-markets.read_character_orders.v1 esi-characters.read_blueprints.v1 esi-contracts.read_character_contracts.v1 esi-wallet.read_corporation_wallets.v1 esi-assets.read_corporation_assets.v1 esi-corporations.read_blueprints.v1 esi-contracts.read_corporation_contracts.v1 esi-corporations.read_starbases.v1 esi-industry.read_corporation_jobs.v1 esi-markets.read_corporation_orders.v1 esi-corporations.read_facilities.v1";
+const ESI_SCOPE = "publicData esi-wallet.read_character_wallet.v1 esi-clones.read_clones.v1 esi-assets.read_assets.v1 esi-industry.read_character_jobs.v1 esi-markets.read_character_orders.v1 esi-characters.read_blueprints.v1 esi-contracts.read_character_contracts.v1 esi-industry.read_character_mining.v1";
 
 export default async function loginEve() {
     const redirectUri = encodeURI(process.env.ESI_REDIRECT_URI as string);


### PR DESCRIPTION
This pull request adds `is_stale` column to the credentials table. This allows the SSO service to mark credentials as stale and skip trying to refresh them over and over again.

The SSO service will send a `CharacterTokenInvalid` message when it encounters stale credentials which allows other services to temporarily ignore the characters with stale credentials.

An example of this can be observed looking at the character listing which will display an `Token Invalid` badge for characters without valid credentials.